### PR TITLE
DM-37132: Remove redundant ctrl_platform_s3df.

### DIFF
--- a/shared_stack.bash
+++ b/shared_stack.bash
@@ -50,7 +50,7 @@ ROOT=/scratch/rubinsw
 # State directory
 STATE=~/shared-stack
 # Top-level products to install
-PRODUCTS="lsst_sitcom ctrl_platform_s3df"
+PRODUCTS="lsst_sitcom"
 # Number of daily releases to keep
 # shellcheck disable=SC2034
 KEEP_d=24


### PR DESCRIPTION
We decided to add this to lsst_distrib, which is in turn in lsst_sitcom.